### PR TITLE
Fix insert command and cleanup resulting text

### DIFF
--- a/Confluence.py
+++ b/Confluence.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     HTML_PRETTIFY = False
 
+
 abspath = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(abspath)
 import markdown2
@@ -347,11 +348,15 @@ class GetConfluencePageCommand(BaseConfluencePageCommand):
             new_view = self.view.window().new_file()
             # set syntax file
             new_view.set_syntax_file("Packages/HTML/HTML.sublime-syntax")
+            new_view.settings().set("auto_indent", False)
 
             # insert the page
-            new_view.run_command("insert_text", {"text": body})
+            new_view.run_command("insert", {"characters": body})
             new_view.set_name(content["title"])
             new_view.settings().set("confluence_content", content)
+            new_view.settings().set("auto_indent", True)
+            new_view.run_command("reindent", {"single_line": False})
+            new_view.run_command("expand_tabs", {"set_translate_tabs": True})
 
             # copy content url
             content_uri = self.confluence_api.get_content_uri(content)


### PR DESCRIPTION
I'm not sure if these changes are generally applicable, or if I just did something wrong with my installation. It wasn't working for me, so this PR is the result of debugging and a little cleanup that I did to figure out why.

The 'insert_text' command wasn't working on my Sublime Text 3 install, so I did some digging
around until I found an example using the 'insert' command with a 'characters' parameter
instead. I tried this, and it works, so I made the change.

Additionally, I was having problems with the auto_indent pushing each successive line
inserted one more tab stop to the right, so I disabled that setting temporarily while
I inserted the text.

Finally, to try to improve the cleanliness of the source a bit more, I added commands
to reindent and translate tabs to spaces.